### PR TITLE
change .hash to to_hash

### DIFF
--- a/lib/nagios_analyzer/section.rb
+++ b/lib/nagios_analyzer/section.rb
@@ -22,7 +22,7 @@ module NagiosAnalyzer
       end
     end
 
-    def hash
+    def to_hash
       return @hash if @hash
       @hash = {}
       @section.each_line do |line|


### PR DESCRIPTION
hash is already a method on Object which hashes the object.
Blindly calling hash on this could yield you nil.hash
