### PR TITLE
Update section.rb to pass 'ruby -w' without warnings

### DIFF
--- a/lib/nagios_analyzer/section.rb
+++ b/lib/nagios_analyzer/section.rb
@@ -23,7 +23,9 @@ module NagiosAnalyzer
     end
 
     def hash
-      return @hash if @hash
+      if defined? @hash
+        return @hash
+      end
       @hash = {}
       @section.each_line do |line|
         line.strip!


### PR DESCRIPTION
When using nagios_analyzer in a script with '-w' turned on, it generates warnings about @hash not being initialized. This proposed change has the same functionality without the warning.
